### PR TITLE
Add delay between puts

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,6 +71,7 @@ type parameters struct {
 	profile            string
 	nosign             bool
 	fanout             *intFlag
+	interDelay         *intFlag
 }
 
 func parseArgs() parameters {
@@ -87,12 +88,14 @@ func parse(cmdline []string) (parameters, error) {
 	var duration intFlag
 	nrequests := intFlag{value: 1000, set: false}
 	fanout := intFlag{value:-1, set: false}
+	interDelay := intFlag{value:0, set:false}
 
 	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	flags.Var(&duration, "duration", "Test duration in seconds")
 	flags.Var(&nrequests, "requests", "Total number of requests")
 	flags.Var(&fanout, "fanout", "Total number of unique fanout copies")
+	flags.Var(&interDelay, "interDelay", "Time in ms to delay between issueing requests")
 
 	var concurrency = flags.Int("concurrency", 1, "Maximum concurrent requests (0=scan concurrency, run with ulimit -n 16384)")
 	var osize = flags.Int64("size", 30*1024, "Object size. Note that s3tester is not ideal for very large objects as the entire body must be read for v4 signing and the aws sdk does not support v4 chunked. Performance may degrade as size increases due to the use of v4 signing without chunked support")
@@ -192,6 +195,12 @@ func parse(cmdline []string) (parameters, error) {
 			}
 		} else {
 			return parameters{}, errors.New("Fanout is (currently) only supported in GET or PUT operations")
+		}
+	}
+
+	if interDelay.set {
+		if (interDelay.value <= 0){
+			return parameters{}, errors.New("Value of interDelay must => 1")
 		}
 	}
 
@@ -331,6 +340,7 @@ func parse(cmdline []string) (parameters, error) {
 		profile:            *profile,
 		nosign:             *nosign,
 		fanout:             &fanout,
+		interDelay:			&interDelay,
 	}
 
 	return args, nil

--- a/s3tester.go
+++ b/s3tester.go
@@ -355,8 +355,12 @@ func worker(results chan<- result, args parameters, credentials *credentials.Cre
 			if args.interDelay.set {
 				elapsed := time.Now().Sub(startSendRequest)
 				sleepTime := time.Duration(args.interDelay.value) * time.Millisecond - elapsed
-				fmt.Printf("Request started at %v and elapsed for %v. Going to sleep for %v\n", startSendRequest, elapsed, sleepTime)
-				time.Sleep(sleepTime)
+				if (sleepTime < 0) {
+					fmt.Printf("Request exceeded the interDelay threshold and elapsed %v. Skipping sleep.\n", elapsed)
+				} else {
+					fmt.Printf("Request started at %v and elapsed for %v. Going to sleep for %v\n", startSendRequest, elapsed, sleepTime)
+					time.Sleep(sleepTime)
+				}
 			}
 		}
 	}

--- a/s3tester.go
+++ b/s3tester.go
@@ -53,6 +53,7 @@ type result struct {
 	Count       int    `json:"totalRequests"`
 	Failcount   int    `json:"failedRequests"`
 	Fanout      int    `json:"fanout"`
+	interDelay  int    `json:"interDelay (ms)"`
 
 	TotalElapsedTime   float64 `json:"totalElapsedTime (ms)"`
 	AverageRequestTime float64 `json:"averageRequestTime (ms)"`
@@ -351,10 +352,12 @@ func worker(results chan<- result, args parameters, credentials *credentials.Cre
 				}
 			}
 			
-			elapsed := time.Now().Sub(startSendRequest)
-			sleepTime := 2000 * time.Millisecond - elapsed
-			fmt.Printf("Request started at %v and elapsed for %v. Going to sleep for %v\n", startSendRequest, elapsed, sleepTime)
-			time.Sleep(sleepTime)
+			if args.interDelay.set {
+				elapsed := time.Now().Sub(startSendRequest)
+				sleepTime := time.Duration(args.interDelay.value) * time.Millisecond - elapsed
+				fmt.Printf("Request started at %v and elapsed for %v. Going to sleep for %v\n", startSendRequest, elapsed, sleepTime)
+				time.Sleep(sleepTime)
+			}
 		}
 	}
 	results <- r

--- a/s3tester.go
+++ b/s3tester.go
@@ -333,6 +333,8 @@ func worker(results chan<- result, args parameters, credentials *credentials.Cre
 
 			r.incrementUniqObjNumCount(args.duration.set)
 
+			startSendRequest := time.Now()
+
 			for repcount := 0; repcount < args.attempts; repcount++ {
 				if source != nil {
 					//size command line arg usually sets the size for each request we need to overwrite
@@ -348,6 +350,11 @@ func worker(results chan<- result, args parameters, credentials *credentials.Cre
 					return
 				}
 			}
+			
+			elapsed := time.Now().Sub(startSendRequest)
+			sleepTime := 2000 * time.Millisecond - elapsed
+			fmt.Printf("Request started at %v and elapsed for %v. Going to sleep for %v\n", startSendRequest, elapsed, sleepTime)
+			time.Sleep(sleepTime)
 		}
 	}
 	results <- r


### PR DESCRIPTION
Added a new flag -interDelay that allows a user to set a delay between requests (in milliseconds).
